### PR TITLE
The Conda notebooks environment should get a name different from the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Install Miniconda or Anaconda from https://docs.conda.io/projects/conda/en/lates
 Create a conda environment:
 
 ```shell
-conda env create --name matchms --file environment.yml
+conda env create --file environment.yml
 ```
 Activate the conda environment:
 
 ```shell
-conda activate matchms
+conda activate matchms-notebooks 
 ```
 
 While ``matchms`` is being developed, we cannot yet install it from


### PR DESCRIPTION
…Conda matchms environment.

This was a bit confusing in the notebooks README.

The Conda notebooks environment should get a name different from the Conda matchms environment.